### PR TITLE
NewClient returns error when AirPlay device not found

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,9 +21,12 @@ type Client struct {
 	connection *connection
 }
 
-func NewClient() *Client {
-	connection := newConnection()
-	return &Client{connection: connection}
+func NewClient() (*Client, error) {
+	connection, err := newConnection()
+	if err != nil {
+		return nil, err
+	}
+	return &Client{connection: connection}, nil
 }
 
 func (c *Client) Play(url string) <-chan error {

--- a/connection.go
+++ b/connection.go
@@ -1,8 +1,8 @@
 package airplay
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 )
@@ -12,17 +12,17 @@ type connection struct {
 	endpoint string
 }
 
-func newConnection() *connection {
+func newConnection() (*connection, error) {
 	devices := Devices()
 
 	if len(devices) == 0 {
-		log.Fatal("AirPlay devices not found")
+		return nil, errors.New("AirPlay devices not found")
 	}
 
 	device := devices[0]
 	endpoint := fmt.Sprintf("http://%s:%d/", device.Addr, device.Port)
 
-	return &connection{device: device, endpoint: endpoint}
+	return &connection{device: device, endpoint: endpoint}, nil
 }
 
 func (c *connection) get(path string) (*http.Response, error) {


### PR DESCRIPTION
AirPlay デバイスがなかった場合，Error を返すようにしました。

これにより go-airplay を利用するアプリを書く場合は明示的にエラーを処理する必要がある:

``` go
cilent, err := airplay.NewClient()
if err != nil {
  // exit
}
```
