### PR TITLE
Support AppleTV 4G

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
   - go get github.com/mattn/goveralls
 
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - go test -covermode=count -coverprofile=profile.cov
+  - $HOME/gopath/bin/goveralls -coverprofile=profile.cov -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ install:
   - go get github.com/miekg/dns
   - go get github.com/gongo/text-parameters
   - go get github.com/DHowett/go-plist
-  - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.4
-  - 1.5
+  - 1.7
 
 install:
   - go get github.com/miekg/dns

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: go
 
+sudo: false
+
 go:
   - 1.7
+
+branches:
+  only:
+    - master
 
 install:
   - go get github.com/miekg/dns

--- a/client.go
+++ b/client.go
@@ -21,6 +21,9 @@ type PlaybackInfo struct {
 	// IsReadyToPlay, if true, content is currently playing or ready to play.
 	IsReadyToPlay bool `plist:"readyToPlay"`
 
+	// ReadyToPlayValue represents the information on whether content is currently playing, ready to play or not.
+	ReadyToPlayValue interface{} `plist:"readyToPlay"`
+
 	// Duration represents playback duration in seconds.
 	Duration float64 `plist:"duration"`
 
@@ -210,6 +213,13 @@ func (c *Client) GetPlaybackInfo() (*PlaybackInfo, error) {
 	info := &PlaybackInfo{}
 	if err := decoder.Decode(info); err != nil {
 		return nil, err
+	}
+
+	switch t := info.ReadyToPlayValue.(type) {
+	case uint64: // AppleTV 4G
+		info.IsReadyToPlay = (t == 1)
+	case bool: // AppleTV 2G, 3G
+		info.IsReadyToPlay = t
 	}
 
 	return info, nil


### PR DESCRIPTION
AppleTV 4G have `readyToPlay` of different type from 2G and 3G.

example: 3G

```plist
<?xml version="1.0" encoding="UTF-8"?>
<dict>
<!-- skip -->

	<key>readyToPlay</key>
	<true/>

<!-- skip -->
</dict>
</plist>
```

example: 4G

```plist
<?xml version="1.0" encoding="UTF-8"?>
<dict>
<!-- skip -->

	<key>readyToPlay</key>
	<integer>1</integer>

<!-- skip -->
</dict>
</plist>
```